### PR TITLE
Fixes for some changes in the diff function

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1329,7 +1329,7 @@ const diffKubernetes = (callback) => {
     getTextForActiveWindow((data, file) => {
         console.log(data, file);
         let kindName = null;
-        let kindObject = null;
+        let kindObject: ResourceKindName | null = null;
         let fileName = null;
 
         let fileFormat = "json";
@@ -1341,7 +1341,7 @@ const diffKubernetes = (callback) => {
                 vscode.window.showErrorMessage('Cannot Parse Kubernetes Object');
                 return;
             }
-            kindName = `${kindObject.resourceType}/${kindObject.resourceName}`;
+            kindName = `${kindObject.kind}/${kindObject.resourceName}`;
             fileName = path.join(os.tmpdir(), `local.${fileFormat}`);
             fs.writeFile(fileName, data, handleError);
         } else if (file) {
@@ -1354,7 +1354,7 @@ const diffKubernetes = (callback) => {
                 vscode.window.showErrorMessage('Cannot Parse Kubernetes Object');
                 return;
             }
-            kindName = `${kindObject.resourceType}/${kindObject.resourceName}`;
+            kindName = `${kindObject.kind}/${kindObject.resourceName}`;
             fileName = file;
             if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document) {
                 const langId = vscode.window.activeTextEditor.document.languageId.toLowerCase();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1337,8 +1337,8 @@ const diffKubernetes = (callback) => {
         if (data) {
             fileFormat = (data.trim().length > 0 && data.trim()[0] == '{') ? "json" : "yaml";
             kindObject = findKindNameForText(data);
-            if (kindObject === null){
-                vscode.window.showErrorMessage('Cannot Parse Kubernetes Object');
+            if (kindObject === null) {
+                vscode.window.showErrorMessage("Can't diff - the open document is not a Kubernetes resource");
                 return;
             }
             kindName = `${kindObject.kind}/${kindObject.resourceName}`;
@@ -1350,8 +1350,8 @@ const diffKubernetes = (callback) => {
                 return; // No open text editor
             }
             kindObject = tryFindKindNameFromEditor();
-            if (kindObject === null){
-                vscode.window.showErrorMessage('Cannot Parse Kubernetes Object');
+            if (kindObject === null) {
+                vscode.window.showErrorMessage("Can't diff - the open document is not a Kubernetes resource");
                 return;
             }
             kindName = `${kindObject.kind}/${kindObject.resourceName}`;


### PR DESCRIPTION
We had to make some changes in the `diffKubernetes` function to handle the new `ResourceKindName` structure.  As this function is away from the main topic of your PR, I'm offering this PR (to your PR) to get them out of the way:

* When the `ResourceKindName.resourceType` member was renamed to `kind`, there was one place (`diffKubernetes`) where a variable was typed as `any` and so the rename didn't get picked up.  The first commit in this PR fixes that.

* I wanted a more explanatory error message if the `ResourceKindName` in `diffKubernetes` was null.  Rather than bug you with more comments on your PR, I thought it would be easier just to provide it to you.